### PR TITLE
Add Notebook Doodles Flickr photo post

### DIFF
--- a/content/posts/notebook_doodles.md
+++ b/content/posts/notebook_doodles.md
@@ -1,0 +1,15 @@
+---
+title: "Notebook Doodles"
+date: 2026-08-01
+draft: false
+tags: ['photo','notebook','doodle']
+categories: ['Creative']
+featured_image: "https://live.staticflickr.com/65535/55338622285_ec6ca5cfb8_c.jpg"
+---
+
+Squid doodles.
+
+{{< flickr "Notebook Doodles"
+           "Squid doodles"
+           "https://www.flickr.com/photos/doodle_m/55338622285"
+           "https://live.staticflickr.com/65535/55338622285_ec6ca5cfb8_c.jpg" >}}


### PR DESCRIPTION
## Summary
- New photo post "Notebook Doodles" (squid doodles) linking the Flickr photo, following the existing single-photo post convention.

## Test plan
- [x] `hugo server -D` and confirm the post renders with the embedded Flickr image and caption