### PR TITLE
Fix build: add gist shortcode for newer Hugo versions

### DIFF
--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,0 +1,1 @@
+<script src="https://gist.github.com/{{ .Get 0 }}/{{ .Get 1 }}.js{{ with .Get 2 }}?file={{ . }}{{ end }}"></script>


### PR DESCRIPTION
## Summary
- The main GitHub Actions build (`.github/workflows/main.yml`, GitHub Pages mirror) started failing with: `ERROR The "gist" shortcode was deprecated in v0.143.0 and removed in v0.156.0.` That workflow doesn't pin a Hugo version and picked up v0.164.0, which no longer ships the built-in `gist` shortcode used by `content/posts/thumbprint.md`.
- Adds `layouts/shortcodes/gist.html`, a project-level shortcode replicating the old built-in behavior (`<script src="https://gist.github.com/user/id.js?file=...">`), so the site builds regardless of Hugo version.

## Test plan
- [x] `hugo --gc --minify` builds locally with no errors
- [x] Verified `public/posts/thumbprint/index.html` renders the same gist embed script tag as before