### PR TITLE
Fix broken RSS follow-icon link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,9 @@ username = "alastairhm"
 username = "@alastair_hm@mastodon.social"
 profilelink = "https://mastodon.social/@alastair_hm"
 
+[params.ananke.social.rss]
+profilelink = "https://blog.0x32.co.uk/index.xml"
+
 [taxonomies]
   category = "categories"
   tag = "tags"


### PR DESCRIPTION
## Summary
- The RSS button in the social follow icons linked to a broken URL (`.../%25!%28EXTRA%20%3Cnil%3E%29`) instead of the feed.
- The ananke theme's default `rss` network entry has an empty `profile` template and expects a `username` param, neither of which was set, so Hugo's `printf` emitted Go's literal `%!(EXTRA <nil>)` error text into the link.
- Fixed by setting `profilelink` explicitly under `[params.ananke.social.rss]`, mirroring the existing override already used for `mastodon`.

## Test plan
- [x] `hugo` builds without errors
- [x] Verified the RSS link in `public/index.html` now points to `https://blog.0x32.co.uk/index.xml`