### PR TITLE
Fix broken ko-fi button image

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ featured_image : "Electron.jpg"
 ---
 Musings of an aging computer nerd hitting 0x32.
 
-[![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/L3L622OXB)
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/L3L622OXB)
 
 [Zazzle Shop Prints, Tshirts and mugs](https://www.zazzle.co.uk/store/doodle_m)
 

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -5,6 +5,6 @@ featured_image : "Electron.jpg"
 ---
 Musings of an aging computer nerd hitting 0x32
 
-[![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/L3L622OXB)
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/L3L622OXB)
 
 [Zazzle Shop Prints, Tshirts and mugs](https://www.zazzle.co.uk/store/doodle_m)


### PR DESCRIPTION
## Summary
- `https://www.ko-fi.com/img/githubbutton_sm.svg` returns 404; ko-fi serves the same asset without the `www.` subdomain (`https://ko-fi.com/img/githubbutton_sm.svg`, confirmed 200).
- Updated both references in `content/_index.md` and `content/posts/_index.md`.

## Test plan
- [x] `hugo` builds without errors
- [x] Confirmed `https://ko-fi.com/img/githubbutton_sm.svg` returns 200