### PR TITLE
Add GoatCounter analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,7 @@ pagerSize = 10
    description = "Views from the wrong side of 0x32"
    rss = "https://blog.0x32.co.uk/index.xml"
    featured_image = "Electron.jpg"
+   goatcounter = "0x32"
 
 [params.ananke.social.share]
 networks = [

--- a/layouts/partials/head-additions.html
+++ b/layouts/partials/head-additions.html
@@ -1,0 +1,5 @@
+{{ if hugo.IsProduction }}
+  {{ with .Site.Params.goatcounter }}
+    <script data-goatcounter="https://{{ . }}.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
## Summary
- Site had no analytics at all (GA internal template exists in the theme but was never configured). Added GoatCounter (privacy-friendly, no cookies) instead of Google Analytics.
- Implemented via `layouts/partials/head-additions.html`, which overrides the theme's own empty partial of the same name (an intentional, empty hook the theme provides for exactly this kind of site-specific head injection) — no changes to the vendored `themes/ananke` submodule.
- Script only renders on production builds (`hugo.IsProduction`), so `hugo server` / local dev never gets counted.
- Site code: `0x32` → `https://0x32.goatcounter.com`

## Test plan
- [x] `hugo` (production) includes the goatcounter `<script>` tag
- [x] `hugo --environment development` omits it