### PR TITLE
Improve tag listing pages

### DIFF
--- a/layouts/tags/term.html
+++ b/layouts/tags/term.html
@@ -1,0 +1,25 @@
+{{/*
+  layouts/tags/term.html
+
+  Single-tag listing page (e.g. /tags/tech/). Overrides the theme default so
+  tag pages get the site header/footer/styling and post cards with featured
+  images, instead of a bare list of links. Categories are untouched and keep
+  the theme's own template.
+*/}}
+{{ define "main" }}
+  <article class="cf pa3 pa4-m pa4-l">
+    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links {{ $.Param "text_color" | default "mid-gray" }}">
+      <h1 class="f1">#{{ .Title }}</h1>
+      <p>{{ len .Pages }} post{{ if ne (len .Pages) 1 }}s{{ end }} tagged &ldquo;{{ .Title }}&rdquo;</p>
+    </div>
+  </article>
+  <div class="mw8 center">
+    <section class="flex-ns flex-wrap justify-around mt5">
+      {{ range .Pages }}
+        <div class="relative w-100 mb4 bg-white">
+          {{ .Render "summary-with-image" }}
+        </div>
+      {{ end }}
+    </section>
+  </div>
+{{ end }}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,8 +1,0 @@
-<!-- layouts/taxonomy/tag.html -->
-<ul>
-    {{ range .Data.Pages }}
-    <li>
-      <a href="{{.RelPermalink}}">{{ .Title }}</a>
-    </li>
-    {{ end }}
-  </ul>


### PR DESCRIPTION
Tag pages (e.g. /tags/tech/) were rendering as a bare, unstyled list of links — a legacy override (`layouts/taxonomy/tag.html`, dating back to 2020) never extended the theme's base template, so they got none of the site's header/nav/footer/CSS.

Replaced it with `layouts/tags/term.html`, scoped to the tags taxonomy only:
- Full site chrome (header, nav, footer, styling)
- Heading with tag name and post count
- Grid of post cards with featured image, date, summary, and read-more link — matching the homepage's post listing style

Categories (`/categories/*`) are untouched and continue to use the theme's own template, which already rendered fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)