### PR TITLE
Add post about A1 Mini prints so far

### DIFF
--- a/content/posts/bambu-a1-mini-prints-so-far.md
+++ b/content/posts/bambu-a1-mini-prints-so-far.md
@@ -1,0 +1,30 @@
+---
+title: "What I've Printed So Far on the A1 Mini"
+date: 2026-08-15T12:00:00+01:00
+draft: false
+tags: ['3d-printing','bambu-lab','hardware','maker']
+categories: ['Making']
+featured_image: "https://live.staticflickr.com/65535/55465908210_a10bfba112_c.jpg"
+---
+
+A follow-up to my [first impressions post]({{< ref "bambu-lab-a1-mini.md" >}}) on the Bambu Lab A1 Mini — I've moved past calibration cubes and benchies now, so here's a look at the first useful things I've actually printed with it.
+
+![Blue bracket printing on the A1 Mini bed, honeycomb infill visible](https://live.staticflickr.com/65535/55465908210_a10bfba112_c.jpg)
+
+First up is a phone stand, printed in blue. Nothing fancy, but it's exactly the kind of small, practical thing that makes owning a printer worth it — five minutes on a model site, an hour or so of printing, and there's a permanent stand sat by the printer holding my phone up at a useful angle.
+
+![Blue phone stand holding a phone next to the printer](https://live.staticflickr.com/65535/55465908350_fa72747925_c.jpg)
+
+Next, a little desk organiser in green — two compartments for pens, bits, and general desk clutter. This one needed supports on one side, and pulling them off cleanly was a good first lesson in not rushing that step.
+
+![Green two-compartment desk organiser](https://live.staticflickr.com/65535/55465683029_7c60b11a9e_c.jpg)
+
+I also printed a Connect 4 board/grid — this is a good test piece for the printer, with a lot of fine detail and repeated small holes across a wide, thin panel. It came out clean with no warping, which I wasn't fully expecting from something this size on the Mini's small bed.
+
+![Green Connect 4 style grid panel propped up on a notebook](https://live.staticflickr.com/65535/55465509961_20174a07aa_c.jpg)
+
+And finally, a small hinged storage box in red — handy for screws, filament samples, or whatever else needs a home. The hinge printed in place and works first time, no assembly required, which still feels a bit like magic.
+
+![Red hinged storage box, open](https://live.staticflickr.com/65535/55465683119_fa32fbc86c_c.jpg)
+
+Five prints in and I'm still firmly in the "print anything that looks interesting" phase rather than designing my own things, but it's already proving useful around the house. More to come as I start working on actual projects rather than just working through other people's models.

--- a/content/posts/bambu-a1-mini-prints-so-far.md
+++ b/content/posts/bambu-a1-mini-prints-so-far.md
@@ -11,20 +11,20 @@ A follow-up to my [first impressions post]({{< ref "bambu-lab-a1-mini.md" >}}) o
 
 ![Blue bracket printing on the A1 Mini bed, honeycomb infill visible](https://live.staticflickr.com/65535/55465908210_a10bfba112_c.jpg)
 
-First up is a phone stand, printed in blue. Nothing fancy, but it's exactly the kind of small, practical thing that makes owning a printer worth it — five minutes on a model site, an hour or so of printing, and there's a permanent stand sat by the printer holding my phone up at a useful angle.
+First up is a phone stand, printed in blue — one I designed myself. Nothing fancy, but it's exactly the kind of small, practical thing that makes owning a printer worth it, and there's something extra satisfying about it being your own design rather than someone else's model. There's now a permanent stand sat by the printer holding my phone up at a useful angle.
 
 ![Blue phone stand holding a phone next to the printer](https://live.staticflickr.com/65535/55465908350_fa72747925_c.jpg)
 
-Next, a little desk organiser in green — two compartments for pens, bits, and general desk clutter. This one needed supports on one side, and pulling them off cleanly was a good first lesson in not rushing that step.
+Next, a little shelf in green, also my own design — this one's sized to hold a Raspberry Pi SBC. This was a good first lesson in supports: it needed them on one side, and pulling them off cleanly took a bit more care than I expected.
 
-![Green two-compartment desk organiser](https://live.staticflickr.com/65535/55465683029_7c60b11a9e_c.jpg)
+![Green Raspberry Pi shelf, self-designed](https://live.staticflickr.com/65535/55465683029_7c60b11a9e_c.jpg)
 
-I also printed a Connect 4 board/grid — this is a good test piece for the printer, with a lot of fine detail and repeated small holes across a wide, thin panel. It came out clean with no warping, which I wasn't fully expecting from something this size on the Mini's small bed.
+I also printed a freestanding pegboard, IKEA Skådis style — this is a good test piece for the printer, with a lot of fine detail and repeated small holes across a wide, thin panel. It came out clean with no warping, which I wasn't fully expecting from something this size on the Mini's small bed.
 
-![Green Connect 4 style grid panel propped up on a notebook](https://live.staticflickr.com/65535/55465509961_20174a07aa_c.jpg)
+![Green freestanding IKEA-style pegboard](https://live.staticflickr.com/65535/55465509961_20174a07aa_c.jpg)
 
 And finally, a small hinged storage box in red — handy for screws, filament samples, or whatever else needs a home. The hinge printed in place and works first time, no assembly required, which still feels a bit like magic.
 
 ![Red hinged storage box, open](https://live.staticflickr.com/65535/55465683119_fa32fbc86c_c.jpg)
 
-Five prints in and I'm still firmly in the "print anything that looks interesting" phase rather than designing my own things, but it's already proving useful around the house. More to come as I start working on actual projects rather than just working through other people's models.
+Five prints in, and it's a nice mix already — some designed myself, some other people's models — and all of it proving genuinely useful around the house. More to come as I keep working through both.


### PR DESCRIPTION
Follow-up post to the A1 Mini unboxing, covering the first five useful things printed: a phone stand, a two-compartment desk organiser, a Connect 4 grid panel, and a hinged storage box, plus a shot of the phone stand mid-print.

🤖 Generated with [Claude Code](https://claude.com/claude-code)