### PR TITLE
Add six-year blog anniversary retrospective post

### DIFF
--- a/content/posts/six-years-of-0x32.md
+++ b/content/posts/six-years-of-0x32.md
@@ -1,0 +1,96 @@
+---
+title: "Six Years of 0x32 (Where Did the Time Go?)"
+date: 2026-08-19T15:40:00+01:00
+draft: false
+tags: ['blog','meta','thoughts','hugo']
+categories: ['General']
+featured_image: "thinking.png"
+---
+
+The [first post](https://blog.0x32.co.uk/posts/my-first-post/) on this blog went up on the 8th of August 2020, two sentences long:
+
+> Welcome to my new blog 0x32 started as I reach the age of 50.
+
+That was six years ago. I genuinely had to check the git log twice, because it doesn't feel like six years — it feels like I set this thing up a couple of years back at most. Where did the time go.
+
+Turns out it went into 164 posts and well over 250 commits, but not at all evenly. Here's every month of it:
+
+<figure>
+<svg viewBox="0 0 744 210" width="100%" role="img" aria-labelledby="postfreq-title postfreq-desc" xmlns="http://www.w3.org/2000/svg" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+<title id="postfreq-title">Posts published per month, August 2020 to August 2026</title>
+<desc id="postfreq-desc">Bar chart of monthly post counts. Steady posting from 2020 to 2023 with sharp October spikes in 2022 and 2023 from Inktober, a near-total gap through 2024 and 2025, and a smaller pickup in August 2026.</desc>
+<line x1="34" y1="82.0" x2="734" y2="82.0" stroke="#d8d6d0" stroke-width="1"/>
+<text x="26" y="85.0" text-anchor="end" font-size="10" fill="#6b6a65">30</text>
+<line x1="34" y1="129.0" x2="734" y2="129.0" stroke="#d8d6d0" stroke-width="1"/>
+<text x="26" y="132.0" text-anchor="end" font-size="10" fill="#6b6a65">20</text>
+<line x1="34" y1="176.0" x2="734" y2="176.0" stroke="#d8d6d0" stroke-width="1"/>
+<text x="26" y="179.0" text-anchor="end" font-size="10" fill="#6b6a65">10</text>
+<line x1="34" y1="176.0" x2="734" y2="176.0" stroke="#9a9890" stroke-width="1"/>
+<rect x="34.00" y="88.7" width="7.62" height="87.3" fill="#2a78d6"/>
+<rect x="43.62" y="151.6" width="7.62" height="24.4" fill="#2a78d6"/>
+<rect x="53.23" y="163.9" width="7.62" height="12.1" fill="#2a78d6"/>
+<rect x="62.85" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="72.47" y="169.4" width="7.62" height="6.6" fill="#2a78d6"/>
+<rect x="91.70" y="163.9" width="7.62" height="12.1" fill="#2a78d6"/>
+<rect x="101.32" y="163.9" width="7.62" height="12.1" fill="#2a78d6"/>
+<rect x="110.93" y="160.9" width="7.62" height="15.1" fill="#2a78d6"/>
+<rect x="120.55" y="160.9" width="7.62" height="15.1" fill="#2a78d6"/>
+<rect x="149.40" y="169.4" width="7.62" height="6.6" fill="#eb6834"/>
+<rect x="168.63" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="216.71" y="160.9" width="7.62" height="15.1" fill="#2a78d6"/>
+<rect x="245.56" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="284.02" y="169.4" width="7.62" height="6.6" fill="#2a78d6"/>
+<rect x="312.87" y="172.4" width="7.62" height="3.6" fill="#eb6834"/>
+<rect x="322.49" y="63.5" width="7.62" height="112.5" fill="#eb6834"/>
+<rect x="360.95" y="102.9" width="7.62" height="73.1" fill="#2a78d6"/>
+<rect x="370.57" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="399.42" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="428.27" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="437.89" y="172.4" width="7.62" height="3.6" fill="#eb6834"/>
+<rect x="447.51" y="41.4" width="7.62" height="134.6" fill="#eb6834"/>
+<rect x="457.13" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="466.74" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="601.06" y="172.4" width="7.62" height="3.6" fill="#eb6834"/>
+<rect x="629.91" y="151.6" width="7.62" height="24.4" fill="#2a78d6"/>
+<rect x="668.37" y="172.4" width="7.62" height="3.6" fill="#2a78d6"/>
+<rect x="726.60" y="147.1" width="7.62" height="28.9" fill="#2a78d6"/>
+<line x1="37.8" y1="176.0" x2="37.8" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="37.8" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2020</text>
+<line x1="95.5" y1="176.0" x2="95.5" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="95.5" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2021</text>
+<line x1="192.7" y1="176.0" x2="192.7" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="192.7" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2022</text>
+<line x1="289.8" y1="176.0" x2="289.8" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="289.8" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2023</text>
+<line x1="386.9" y1="176.0" x2="386.9" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="386.9" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2024</text>
+<line x1="484.1" y1="176.0" x2="484.1" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="484.1" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2025</text>
+<line x1="581.2" y1="176.0" x2="581.2" y2="180.0" stroke="#9a9890" stroke-width="1"/>
+<text x="581.2" y="192.0" text-anchor="middle" font-size="10" fill="#6b6a65">2026</text>
+<text x="34" y="14" font-size="12" fill="#2b2a27" font-weight="600">Posts per month, Aug 2020 – Aug 2026</text>
+<rect x="524" y="8" width="10" height="10" fill="#2a78d6"/>
+<text x="538" y="17" font-size="10" fill="#3a3934">Other months</text>
+<rect x="624" y="8" width="10" height="10" fill="#eb6834"/>
+<text x="638" y="17" font-size="10" fill="#3a3934">October (Inktober)</text>
+</svg>
+<figcaption style="font-size: 0.85em; color: #6b6a65; margin-top: 0.3em;">Monthly post counts, August 2020 – August 2026. Orange bars are Octobers, most of it Inktober output.</figcaption>
+</figure>
+
+The launch-month spike, four years of a decent drumbeat, two enormous Inktober-fuelled Octobers, then a near-total flatline through 2024 and most of 2025. I don't have a dramatic reason for the flatline — life got busier, the blog quietly stopped being the thing I reached for, and once a gap opens up it's easy to let it stay open. No hiatus announcement, just months of near-nothing, stacking up quietly in the background without me really clocking it in real time. That's the "where did the time go" of it in one picture.
+
+What's brought it back this year is partly having new things worth writing about — a 3D printer, some AI-assisted coding sessions, generative art scripts — and partly just deciding to treat the blog itself as a small project worth tending again rather than a finished thing sitting untouched.
+
+Looking back over the categories, the split is telling too:
+
+- **Creative** — 85 posts, by far the biggest bucket: photos, drawings, Inktober entries, generative art.
+- **Technical** — 14, plus a scatter of Geek/Python/RaspberryPi tags.
+- **Retro** — 8, old hardware and software nostalgia.
+
+I set this up expecting a tech blog and it turned into mostly a creative one, which in hindsight tracks — the tech posts are the ones I *can* write, the creative ones are the ones I actually *want* to.
+
+The other thing that's been fun, separate from the writing itself, is that the blog has been its own small ongoing project to tinker with. It started on Travis CI; that's long gone. The theme's been swapped, custom shortcodes added for embedding Flickr photos and LBRY videos, a proper multi-target deploy pipeline built out (S3 + CloudFront as the primary site, a GitHub Pages mirror as backup), and — very recently — a proper cleanup pass to fix rot that had quietly built up: broken links, a missing favicon, no analytics at all until [GoatCounter got wired in a couple of weeks ago]({{< ref "goatcounter-two-weeks.md" >}}). None of that is content, exactly, but it's been just as satisfying as writing the posts — maybe more, some months.
+
+I won't pretend I wouldn't like more people to stumble across it — the GoatCounter numbers make it pretty clear this is a small, quiet corner of the internet, and part of me wishes it were better visited. But if even a handful of the people who have landed here got some actual use out of a post, or just a few minutes of entertainment out of the Inktober scribbles or a fractal render, that's plenty of reason to have kept going.
+
+Six years, a five-figure number of commits away from being embarrassing, and a blog that's gone quiet and loud again a couple of times over. Here's to whatever the next six look like — hopefully with fewer multi-year gaps, but no promises.


### PR DESCRIPTION
Six years since the first post (8 Aug 2020) — a retrospective covering:

- 164 posts, an inline SVG chart of posting frequency by month (launch spike, steady 2020-23, two huge Inktober-driven Octobers, the 2024-25 flatline, this year's pickup)
- the Creative vs Technical category split
- enjoying tending the blog's own tooling (deploy pipeline, shortcodes, cleanup pass) as much as writing posts

Verified locally with `hugo server -D`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)