### PR TITLE
Add scheduled post: Doomheaven moves to GitHub Pages

### DIFF
--- a/content/posts/doomheaven-github-pages.md
+++ b/content/posts/doomheaven-github-pages.md
@@ -1,0 +1,18 @@
+---
+title: "Doomheaven Moves to GitHub Pages"
+date: 2026-08-21T08:00:00+01:00
+draft: false
+tags: ['retro','gaming','doom','web','github']
+categories: ['Retro']
+featured_image: "/invader.jpg"
+---
+
+[doomheaven.uk](https://doomheaven.uk) is moving house.
+
+It started life as a Doom fan site back in the late 90s — WADs, screenshots, whatever bits of Doom nonsense felt worth putting on the web at the time. It's sat online quietly ever since, hosted the whole way through by [teamhellspawn.com](https://teamhellspawn.com), who've now let me know they're winding things down.
+
+I want to say a proper thank you to them for that. Free webspace for the better part of three decades is a genuinely long time to keep something ticking over for no reason beyond being decent about it, and rather than just switching it off, they gave me the chance to get everything off in one piece before it went. Not everyone bothers with that on the way out, so it was appreciated.
+
+The site's now moved to GitHub Pages, source and all at [github.com/alastairhm/doomheaven](https://github.com/alastairhm/doomheaven), still living at [doomheaven.uk](https://doomheaven.uk). Static, free, and about as low-maintenance a place as it could ask for — should be good for another few decades.
+
+Here's to teamhellspawn, and to a small corner of late-90s Doom still being online.

--- a/content/posts/doomheaven-github-pages.md
+++ b/content/posts/doomheaven-github-pages.md
@@ -4,7 +4,7 @@ date: 2026-08-21T08:00:00+01:00
 draft: false
 tags: ['retro','gaming','doom','web','github']
 categories: ['Retro']
-featured_image: "/invader.jpg"
+featured_image: "https://upload.wikimedia.org/wikipedia/en/2/29/Doom_II_-_Hell_on_Earth_Coverart.png"
 ---
 
 [doomheaven.uk](https://doomheaven.uk) is moving house.


### PR DESCRIPTION
Adds a new post scheduled for Friday 2026-08-21 08:00 BST, about moving doomheaven.uk from teamhellspawn.com to GitHub Pages.

Note: Hugo excludes future-dated content from the build by default (no `--buildFuture` in the deploy workflows), so merging this now won't publish it immediately — it'll only go live once a build runs on or after the post's date. If you want it live exactly at 8am Friday, something will need to trigger a rebuild/redeploy around then (e.g. a small unrelated push, or a manual `hugo deploy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)