### PR TITLE
Add workflow_dispatch trigger to deploy workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch: {}
 
 jobs:
   build:

--- a/.github/workflows/s3.yaml
+++ b/.github/workflows/s3.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
Adds `workflow_dispatch: {}` to both `.github/workflows/main.yml` and `.github/workflows/s3.yaml` so either deploy can be re-run on demand (Actions UI, or `gh workflow run build` / `gh workflow run "Hugo Build and Deploy to S3"`) without needing a real (or empty) commit to master.

Useful going forward for republishing future-dated scheduled posts once their date passes, without waiting for the next real content push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)